### PR TITLE
🤧Virus Spawner

### DIFF
--- a/Scenes/DNAView.tscn
+++ b/Scenes/DNAView.tscn
@@ -1,22 +1,38 @@
-[gd_scene load_steps=3 format=3 uid="uid://cbcarb7s7vlip"]
+[gd_scene load_steps=5 format=3 uid="uid://cbcarb7s7vlip"]
 
-[ext_resource type="PackedScene" uid="uid://c1if8hsn7aob" path="res://Scenes/mock_mainGame.tscn" id="1_gpxm0"]
+[ext_resource type="Script" path="res://Scripts/DNAView.gd" id="1_3lxgb"]
+[ext_resource type="PackedScene" uid="uid://cgci433uj7qpp" path="res://Scenes/mock_mainGame.tscn" id="1_gpxm0"]
+[ext_resource type="PackedScene" uid="uid://28d7c2hau37f" path="res://Scenes/virus.tscn" id="2_7opqa"]
 
-[sub_resource type="BoxMesh" id="BoxMesh_e7d8l"]
+[sub_resource type="Curve3D" id="Curve3D_w15hm"]
+_data = {
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, 5.37667, 0.2042, -4.63271, 0, 0, 0, 0, 0, 0, 3.55603, 0.202564, -0.0833865, 0, 0, 0, 0, 0, 0, -3.09061, 0.0620352, 1.58507, 0, 0, 0, 0, 0, 0, -6.12812, 0.216451, -2.66702, 0, 0, 0, 0, 0, 0, 5.37667, 0.2042, -4.63271),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0)
+}
+point_count = 5
 
 [node name="DnaView" type="Node3D"]
+script = ExtResource("1_3lxgb")
+mob_scene = ExtResource("2_7opqa")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(0.926758, 0, 0.375658, 0, 1, 0, -0.375658, 0, 0.926758, 0.877569, 0, 1.65196)
-
-[node name="StaticBody3D" type="StaticBody3D" parent="."]
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.66095, 0.905463, 0.847444)
-mesh = SubResource("BoxMesh_e7d8l")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.69734, 0, 0.71674, -0.449034, 0.779425, 0.43688, -0.558646, -0.626495, 0.543525, 2.09304, 1.23465, 1.93131)
 
 [node name="MockMainGame" parent="." instance=ExtResource("1_gpxm0")]
 transform = Transform3D(0.373878, 0, -0.927478, 0, 1, 0, 0.927478, 0, 0.373878, -1.34684, 0, -9.91037)
+
+[node name="SpawnPath" type="Path3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.209005, -0.147326, -0.127531)
+curve = SubResource("Curve3D_w15hm")
+
+[node name="SpawnLocation" type="PathFollow3D" parent="SpawnPath"]
+transform = Transform3D(-0.928386, -0.000124048, 0.371549, -7.27575e-12, 0.999991, 0.000333868, -0.37154, 0.000309966, -0.928409, 5.37667, 0.2042, -4.63271)
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 0.5
+autostart = true
+
+[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]

--- a/Scenes/mock_mainGame.tscn
+++ b/Scenes/mock_mainGame.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://c1if8hsn7aob"]
+[gd_scene load_steps=2 format=3 uid="uid://cgci433uj7qpp"]
 
-[ext_resource type="PackedScene" uid="uid://bmyp320n2py1p" path="res://Scenes/mock_baraCuCerc.tscn" id="1_l6uff"]
+[ext_resource type="PackedScene" path="res://Scenes/mock_baraCuCerc.tscn" id="1_l6uff"]
 
 [node name="MockMainGame" type="Node3D"]
 

--- a/Scenes/virus.tscn
+++ b/Scenes/virus.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=3 uid="uid://28d7c2hau37f"]
+
+[ext_resource type="Script" path="res://Scripts/Virus.gd" id="1_h5x1t"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_myx7m"]
+
+[node name="CharacterBody3D" type="CharacterBody3D"]
+script = ExtResource("1_h5x1t")
+min_speed = 2
+max_speed = 6
+
+[node name="StaticBody3D" type="StaticBody3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticBody3D"]
+mesh = SubResource("SphereMesh_myx7m")
+
+[node name="VisibleOnScreenNotifier3D" type="VisibleOnScreenNotifier3D" parent="."]
+aabb = AABB(-1, -1, -0.843105, 2, 2, 1.64422)

--- a/Scripts/DNAView.gd
+++ b/Scripts/DNAView.gd
@@ -1,0 +1,20 @@
+extends Node
+
+@export var mob_scene: PackedScene
+
+
+func _on_timer_timeout() -> void:
+	# Create a new instance of the Mob scene.
+	var mob = mob_scene.instantiate()
+
+	# Choose a random location on the SpawnPath.
+	# We store the reference to the SpawnLocation node.
+	var mob_spawn_location = get_node("SpawnPath/SpawnLocation")
+	# And give it a random offset.
+	mob_spawn_location.progress_ratio = randf()
+
+	var player_position = Vector3(0,0,0);
+	mob.initialize(mob_spawn_location.position, player_position)
+
+	# Spawn the mob by adding it to the Main scene.
+	add_child(mob)

--- a/Scripts/Virus.gd
+++ b/Scripts/Virus.gd
@@ -1,0 +1,29 @@
+extends CharacterBody3D
+
+# Minimum speed of the mob in meters per second.
+@export var min_speed = 10
+# Maximum speed of the mob in meters per second.
+@export var max_speed = 18
+
+func _physics_process(_delta):
+	move_and_slide()
+
+# This function will be called from the Main scene.
+func initialize(start_position, player_position):
+	# We position the mob by placing it at start_position
+	# and rotate it towards player_position, so it looks at the player.
+	look_at_from_position(start_position, player_position, Vector3.UP)
+	# Rotate this mob randomly within range of -45 and +45 degrees,
+	# so that it doesn't move directly towards the player.
+	rotate_y(randf_range(-PI / 4, PI / 4))
+
+	# We calculate a random speed (integer)
+	var random_speed = randi_range(min_speed, max_speed)
+	# We calculate a forward velocity that represents the speed.
+	velocity = Vector3.FORWARD * random_speed
+	# We then rotate the velocity vector based on the mob's Y rotation
+	# in order to move in the direction the mob is looking.
+	velocity = velocity.rotated(Vector3.UP, rotation.y)
+
+func _on_visible_on_screen_notifier_3d_screen_exited():
+	queue_free()


### PR DESCRIPTION
Add a frugal instantiation system in the DNA viewer which listens to a timer and once every 0.5s a new virus is spawned.

The speed and location of the viruses spawned is random.
The SpawnPath can be set from the DNAView scene. It spawns entities along that path.
![image](https://github.com/user-attachments/assets/d57405f4-f9a7-4e07-a691-750a3463809a)


The viruses are freed from memory once they exit the screen with `queue_free`.